### PR TITLE
fix CI typecheck path mapping and workspace projects.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Typecheck
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Lint
         run: npm run lint --if-present

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build:admin": "npm run build --workspace admin-new",
     "build:storefront": "npm run build --workspace storefront",
     "lint:admin": "npm run lint --workspace admin-new",
-    "lint:storefront": "npm run lint --workspace storefront"
+    "lint:storefront": "npm run lint --workspace storefront",
+    "typecheck": "npx tsc --noEmit -p packages/shared && npx tsc --noEmit -p admin-new && npx tsc --noEmit -p storefront-new/storefront"
   },
   "workspaces": [
     "admin-new",

--- a/packages/shared/src/lib/logger.ts
+++ b/packages/shared/src/lib/logger.ts
@@ -3,32 +3,50 @@
  * Respects NODE_ENV to avoid logging in production
  */
 
-type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+type LogLevel = "debug" | "info" | "warn" | "error";
 
 interface LogContext {
   [key: string]: unknown;
 }
 
-const isDevelopment = process.env.NODE_ENV === 'development';
+const isDevelopment = process.env.NODE_ENV === "development";
 
-const logWithLevel = (level: LogLevel, message: string, context?: LogContext) => {
-  if (!isDevelopment && level === 'debug') return;
+type ConsoleMethod = (message?: unknown, ...optionalParams: unknown[]) => void;
+
+const consoleMethods: Record<LogLevel, ConsoleMethod> = {
+  debug: console.debug.bind(console),
+  info: console.info.bind(console),
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+};
+
+const logWithLevel = (
+  level: LogLevel,
+  message: string,
+  context?: LogContext,
+) => {
+  if (!isDevelopment && level === "debug") return;
 
   const timestamp = new Date().toISOString();
   const prefix = `[${timestamp}] [${level.toUpperCase()}]`;
-  
+  const log = consoleMethods[level];
+
   if (context) {
-    console[level as keyof typeof console](`${prefix} ${message}`, context);
+    log(`${prefix} ${message}`, context);
   } else {
-    console[level as keyof typeof console](`${prefix} ${message}`);
+    log(`${prefix} ${message}`);
   }
 };
 
 export const logger = {
-  debug: (message: string, context?: LogContext) => logWithLevel('debug', message, context),
-  info: (message: string, context?: LogContext) => logWithLevel('info', message, context),
-  warn: (message: string, context?: LogContext) => logWithLevel('warn', message, context),
-  error: (message: string, context?: LogContext) => logWithLevel('error', message, context),
+  debug: (message: string, context?: LogContext) =>
+    logWithLevel("debug", message, context),
+  info: (message: string, context?: LogContext) =>
+    logWithLevel("info", message, context),
+  warn: (message: string, context?: LogContext) =>
+    logWithLevel("warn", message, context),
+  error: (message: string, context?: LogContext) =>
+    logWithLevel("error", message, context),
 };
 
 export default logger;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,18 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@ecommerce/*": ["packages/*/src/*"],
-      "@ecommerce/shared": ["packages/shared/src"]
+      "@ecommerce/shared": ["packages/shared/src"],
+      "@ecommerce/shared/*": ["packages/shared/src/*"]
     }
-  }
+  },
+  "include": ["types/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "**/node_modules",
+    "**/dist",
+    "**/.next",
+    "admin-new",
+    "storefront-new",
+    "packages"
+  ]
 }

--- a/types/root-shim.ts
+++ b/types/root-shim.ts
@@ -1,0 +1,2 @@
+/** Placeholder so the root tsconfig has at least one input for `tsc`. */
+export {};


### PR DESCRIPTION
TypeScript rejects multi-star path substitutions; typecheck shared, admin, and storefront separately so CI matches real app configs.

## Summary

(Reference related issue: e.g. #123)

## Changes
- List of changes made

## Checklist
- [ ] Linked issue in PR description
- [ ] CI: typecheck / lint / tests pass
- [ ] Tests added/updated
- [ ] Documentation / Notion updated

## Testing notes
- How to test locally

## Screenshots / Recordings
- Optional

## Reviewer notes
- Any special review guidance
